### PR TITLE
hotfix: mobile toc appearing in posts without toc

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,12 +7,14 @@
     {{ end }}
 
     <article>
+        {{- if (index .Params "table-of-contents") }}
         <div id="post-toc-mobile">
             <button id="post-toc-btn" class="dropbox-btn" onclick="toggleDropbox('post-toc')" >☰</button>
             <div id="post-toc" class="dropbox-content table-of-contents float">
                 {{ partial "toc.html" . }}
             </div>
         </div>
+        {{ end }}
         <h2>{{ .Title }}</h2>
         {{ $tags := .Params.tags }}
         tags:


### PR DESCRIPTION
we forget about the mobile toc appearing in posts without a toc.
![image](https://github.com/user-attachments/assets/abacbb17-c36d-4508-b9cd-035e694228df)
